### PR TITLE
Eliminate Local Dispute ID

### DIFF
--- a/contracts/IDisputeResolver.sol
+++ b/contracts/IDisputeResolver.sol
@@ -22,55 +22,49 @@ abstract contract IDisputeResolver is IArbitrable, IEvidence {
     string public constant VERSION = "1.0.0";
 
     /** @dev Raised when a contribution is made, inside fundAppeal function.
-     *  @param localDisputeID The dispute id as in the arbitrable contract.
+     *  @param disputeID The dispute id as in the arbitrable contract.
      *  @param round The round number the contribution was made to.
      *  @param ruling Indicates the ruling option which got the contribution.
      *  @param contributor Caller of fundAppeal function.
      *  @param amount Contribution amount.
      */
-    event Contribution(uint256 indexed localDisputeID, uint256 indexed round, uint256 ruling, address indexed contributor, uint256 amount);
+    event Contribution(uint256 indexed disputeID, uint256 indexed round, uint256 ruling, address indexed contributor, uint256 amount);
 
     /** @dev Raised when a contributor withdraws non-zero value.
-     *  @param localDisputeID The dispute id as in arbitrable contract.
+     *  @param disputeID The dispute id as in arbitrable contract.
      *  @param round The round number the withdrawal was made from.
      *  @param ruling Indicates the ruling option which contributor gets rewards from.
      *  @param contributor The beneficiary of withdrawal.
      *  @param reward Total amount of deposits reimbursed plus rewards. This amount will be sent to contributor as an effect of calling withdrawFeesAndRewards function.
      */
-    event Withdrawal(uint256 indexed localDisputeID, uint256 indexed round, uint256 ruling, address indexed contributor, uint256 reward);
+    event Withdrawal(uint256 indexed disputeID, uint256 indexed round, uint256 ruling, address indexed contributor, uint256 reward);
 
     /** @dev To be raised when a ruling option is fully funded for appeal.
-     *  @param localDisputeID The dispute id as in arbitrable contract.
+     *  @param disputeID The dispute id as in arbitrable contract.
      *  @param round Round code of the appeal. Starts from 0.
      *  @param ruling THe ruling option which just got fully funded.
      */
-    event RulingFunded(uint256 indexed localDisputeID, uint256 indexed round, uint256 indexed ruling);
-
-    /** @dev Maps external (arbitrator side) dispute id to local (arbitrable) dispute id. This is necessary to obtain local dispute data by arbitrators id.
-     *  @param _externalDisputeID Dispute id as in arbitrator side.
-     *  @return localDisputeID Dispute id as in arbitrable contract.
-     */
-    function externalIDtoLocalID(uint256 _externalDisputeID) external virtual returns (uint256 localDisputeID);
+    event RulingFunded(uint256 indexed disputeID, uint256 indexed round, uint256 indexed ruling);
 
     /** @dev Returns number of possible ruling options. Valid rulings are [0, return value].
-     *  @param _localDisputeID Dispute id as in arbitrable contract.
+     *  @param disputeID Dispute id as in arbitrable contract.
      *  @return count The number of ruling options.
      */
-    function numberOfRulingOptions(uint256 _localDisputeID) external view virtual returns (uint256 count);
+    function numberOfRulingOptions(uint256 disputeID) external view virtual returns (uint256 count);
 
     /** @dev Allows to submit evidence for a given dispute.
-     *  @param _localDisputeID Dispute id as in arbitrable contract.
-     *  @param _evidenceURI Link to evidence.
+     *  @param disputeID Dispute id as in arbitrable contract.
+     *  @param  evidenceURI Link to evidence.
      */
-    function submitEvidence(uint256 _localDisputeID, string calldata _evidenceURI) external virtual;
+    function submitEvidence(uint256 disputeID, string calldata evidenceURI) external virtual;
 
     /** @dev TRUSTED. Manages contributions and calls appeal function of the specified arbitrator to appeal a dispute. This function lets appeals be crowdfunded.
         Note that we don’t need to check that msg.value is enough to pay arbitration fees as it’s the responsibility of the arbitrator contract.
-     *  @param _localDisputeID Dispute id as in arbitrable contract.
-     *  @param _ruling The ruling option to which the caller wants to contribute.
+     *  @param disputeID Dispute id as in arbitrable contract.
+     *  @param ruling The ruling option to which the caller wants to contribute.
      *  @return fullyFunded True if the ruling option got fully funded as a result of this contribution.
      */
-    function fundAppeal(uint256 _localDisputeID, uint256 _ruling) external payable virtual returns (bool fullyFunded);
+    function fundAppeal(uint256 disputeID, uint256 ruling) external payable virtual returns (bool fullyFunded);
 
     /** @dev Returns stake multipliers.
      *  @return winnerStakeMultiplier Winners stake multiplier.
@@ -92,52 +86,52 @@ abstract contract IDisputeResolver is IArbitrable, IEvidence {
         );
 
     /** @dev Allows to withdraw any reimbursable fees or rewards after the dispute gets solved.
-     *  @param _localDisputeID Dispute id as in arbitrable contract.
-     *  @param _contributor The address to withdraw its rewards.
-     *  @param _roundNumber The number of the round caller wants to withdraw from.
-     *  @param _ruling A ruling option that the caller wants to withdraw fees and rewards related to it.
+     *  @param disputeID Dispute id as in arbitrable contract.
+     *  @param contributor The address to withdraw its rewards.
+     *  @param roundNumber The number of the round caller wants to withdraw from.
+     *  @param ruling A ruling option that the caller wants to withdraw fees and rewards related to it.
      *  @return sum The reward that is going to be paid as a result of this function call, if it's not zero.
      */
     function withdrawFeesAndRewards(
-        uint256 _localDisputeID,
-        address payable _contributor,
-        uint256 _roundNumber,
-        uint256 _ruling
+        uint256 disputeID,
+        address payable contributor,
+        uint256 roundNumber,
+        uint256 ruling
     ) external virtual returns (uint256 sum);
 
     /** @dev Allows to withdraw any reimbursable fees or rewards after the dispute gets solved. For multiple ruling options at once.
-     *  @param _localDisputeID Dispute id as in arbitrable contract.
-     *  @param _contributor The address to withdraw its rewards.
-     *  @param _roundNumber The number of the round caller wants to withdraw from.
-     *  @param _contributedTo Rulings that received contributions from contributor.
+     *  @param disputeID Dispute id as in arbitrable contract.
+     *  @param contributor The address to withdraw its rewards.
+     *  @param roundNumber The number of the round caller wants to withdraw from.
+     *  @param contributedTo Rulings that received contributions from contributor.
      */
     function withdrawFeesAndRewardsForMultipleRulings(
-        uint256 _localDisputeID,
-        address payable _contributor,
-        uint256 _roundNumber,
-        uint256[] memory _contributedTo
+        uint256 disputeID,
+        address payable contributor,
+        uint256 roundNumber,
+        uint256[] memory contributedTo
     ) external virtual;
 
     /** @dev Allows to withdraw any rewards or reimbursable fees after the dispute gets resolved. For multiple rulings options and for all rounds at once.
-     *  @param _localDisputeID Dispute id as in arbitrable contract.
-     *  @param _contributor The address to withdraw its rewards.
-     *  @param _contributedTo Rulings that received contributions from contributor.
+     *  @param disputeID Dispute id as in arbitrable contract.
+     *  @param contributor The address to withdraw its rewards.
+     *  @param contributedTo Rulings that received contributions from contributor.
      */
     function withdrawFeesAndRewardsForAllRounds(
-        uint256 _localDisputeID,
-        address payable _contributor,
-        uint256[] memory _contributedTo
+        uint256 disputeID,
+        address payable contributor,
+        uint256[] memory contributedTo
     ) external virtual;
 
     /** @dev Returns the sum of withdrawable amount.
-     *  @param _localDisputeID Dispute id as in arbitrable contract.
-     *  @param _contributor The contributor for which to query.
-     *  @param _contributedTo Ruling options to look for potential withdrawals.
+     *  @param disputeID Dispute id as in arbitrable contract.
+     *  @param contributor The contributor for which to query.
+     *  @param contributedTo Ruling options to look for potential withdrawals.
      *  @return sum The total amount available to withdraw.
      */
     function getTotalWithdrawableAmount(
-        uint256 _localDisputeID,
-        address payable _contributor,
-        uint256[] memory _contributedTo
+        uint256 disputeID,
+        address payable contributor,
+        uint256[] memory contributedTo
     ) public view virtual returns (uint256 sum);
 }

--- a/contracts/IDisputeResolver.sol
+++ b/contracts/IDisputeResolver.sol
@@ -15,7 +15,7 @@ import "@kleros/erc-792/contracts/erc-1497/IEvidence.sol";
 import "@kleros/erc-792/contracts/IArbitrator.sol";
 
 /**
- *  @title This is a common interface for apps to interact with disputes’ standard operations.
+ *  @title This is a common interface for apps to interact with Dispute Resolver's standard operations.
  *  Sets a standard arbitrable contract implementation to provide a general purpose user interface.
  */
 abstract contract IDisputeResolver is IArbitrable, IEvidence {
@@ -28,7 +28,7 @@ abstract contract IDisputeResolver is IArbitrable, IEvidence {
      *  @param contributor Caller of fundAppeal function.
      *  @param amount Contribution amount.
      */
-    event Contribution(uint256 indexed disputeID, uint256 indexed round, uint256 ruling, address indexed contributor, uint256 amount);
+    event Contribution(IArbitrator indexed arbitrator, uint256 indexed disputeID, uint256 indexed round, uint256 ruling, address contributor, uint256 amount);
 
     /** @dev Raised when a contributor withdraws non-zero value.
      *  @param disputeID The dispute id as in arbitrable contract.
@@ -37,26 +37,30 @@ abstract contract IDisputeResolver is IArbitrable, IEvidence {
      *  @param contributor The beneficiary of withdrawal.
      *  @param reward Total amount of deposits reimbursed plus rewards. This amount will be sent to contributor as an effect of calling withdrawFeesAndRewards function.
      */
-    event Withdrawal(uint256 indexed disputeID, uint256 indexed round, uint256 ruling, address indexed contributor, uint256 reward);
+    event Withdrawal(IArbitrator indexed arbitrator, uint256 indexed disputeID, uint256 indexed round, uint256 ruling, address contributor, uint256 reward);
 
     /** @dev To be raised when a ruling option is fully funded for appeal.
      *  @param disputeID The dispute id as in arbitrable contract.
      *  @param round Round code of the appeal. Starts from 0.
      *  @param ruling THe ruling option which just got fully funded.
      */
-    event RulingFunded(uint256 indexed disputeID, uint256 indexed round, uint256 indexed ruling);
+    event RulingFunded(IArbitrator indexed arbitrator, uint256 indexed disputeID, uint256 indexed round, uint256 ruling);
 
     /** @dev Returns number of possible ruling options. Valid rulings are [0, return value].
      *  @param disputeID Dispute id as in arbitrable contract.
      *  @return count The number of ruling options.
      */
-    function numberOfRulingOptions(uint256 disputeID) external view virtual returns (uint256 count);
+    function numberOfRulingOptions(IArbitrator arbitrator, uint256 disputeID) external view virtual returns (uint256 count);
 
     /** @dev Allows to submit evidence for a given dispute.
      *  @param disputeID Dispute id as in arbitrable contract.
      *  @param  evidenceURI Link to evidence.
      */
-    function submitEvidence(uint256 disputeID, string calldata evidenceURI) external virtual;
+    function submitEvidence(
+        IArbitrator arbitrator,
+        uint256 disputeID,
+        string calldata evidenceURI
+    ) external virtual;
 
     /** @dev TRUSTED. Manages contributions and calls appeal function of the specified arbitrator to appeal a dispute. This function lets appeals be crowdfunded.
         Note that we don’t need to check that msg.value is enough to pay arbitration fees as it’s the responsibility of the arbitrator contract.
@@ -64,7 +68,11 @@ abstract contract IDisputeResolver is IArbitrable, IEvidence {
      *  @param ruling The ruling option to which the caller wants to contribute.
      *  @return fullyFunded True if the ruling option got fully funded as a result of this contribution.
      */
-    function fundAppeal(uint256 disputeID, uint256 ruling) external payable virtual returns (bool fullyFunded);
+    function fundAppeal(
+        IArbitrator arbitrator,
+        uint256 disputeID,
+        uint256 ruling
+    ) external payable virtual returns (bool fullyFunded);
 
     /** @dev Returns stake multipliers.
      *  @return winnerStakeMultiplier Winners stake multiplier.
@@ -93,6 +101,7 @@ abstract contract IDisputeResolver is IArbitrable, IEvidence {
      *  @return sum The reward that is going to be paid as a result of this function call, if it's not zero.
      */
     function withdrawFeesAndRewards(
+        IArbitrator arbitrator,
         uint256 disputeID,
         address payable contributor,
         uint256 roundNumber,
@@ -106,6 +115,7 @@ abstract contract IDisputeResolver is IArbitrable, IEvidence {
      *  @param contributedTo Rulings that received contributions from contributor.
      */
     function withdrawFeesAndRewardsForMultipleRulings(
+        IArbitrator arbitrator,
         uint256 disputeID,
         address payable contributor,
         uint256 roundNumber,
@@ -118,6 +128,7 @@ abstract contract IDisputeResolver is IArbitrable, IEvidence {
      *  @param contributedTo Rulings that received contributions from contributor.
      */
     function withdrawFeesAndRewardsForAllRounds(
+        IArbitrator arbitrator,
         uint256 disputeID,
         address payable contributor,
         uint256[] memory contributedTo
@@ -130,6 +141,7 @@ abstract contract IDisputeResolver is IArbitrable, IEvidence {
      *  @return sum The total amount available to withdraw.
      */
     function getTotalWithdrawableAmount(
+        IArbitrator arbitrator,
         uint256 disputeID,
         address payable contributor,
         uint256[] memory contributedTo

--- a/contracts/RealitioProxyWithAppeals
+++ b/contracts/RealitioProxyWithAppeals
@@ -244,7 +244,7 @@ contract RealitioArbitratorProxyWithAppeals is IDisputeResolver {
 
         // Take up to the amount necessary to fund the current round at the current costs.
         uint256 contribution = totalCost.subCap(round.paidFees[_answer]) > msg.value ? msg.value : totalCost.subCap(round.paidFees[_answer]);
-        emit Contribution(_questionID, lastRoundID, _answer, msg.sender, contribution);
+        emit Contribution(arbitrator, _questionID, lastRoundID, _answer, msg.sender, contribution);
 
         round.contributions[msg.sender][_answer] += contribution;
         round.paidFees[_answer] += contribution;
@@ -252,7 +252,7 @@ contract RealitioArbitratorProxyWithAppeals is IDisputeResolver {
             round.feeRewards += round.paidFees[_answer];
             round.fundedAnswers.push(_answer);
             round.hasPaid[_answer] = true;
-            emit RulingFunded(_questionID, lastRoundID, _answer);
+            emit RulingFunded(arbitrator, _questionID, lastRoundID, _answer);
         }
 
         if (round.fundedAnswers.length > 1) {
@@ -289,7 +289,9 @@ contract RealitioArbitratorProxyWithAppeals is IDisputeResolver {
         } else if (!round.hasPaid[question.answer]) {
             // Reimburse unspent fees proportionally if the ultimate winner didn't pay appeal fees fully.
             // Note that if only one side is funded it will become a winner and this part of the condition won't be reached.
-            reward = round.fundedAnswers.length > 1 ? (round.contributions[_beneficiary][_answer] * round.feeRewards) / (round.paidFees[round.fundedAnswers[0]] + round.paidFees[round.fundedAnswers[1]]) : 0;
+            reward = round.fundedAnswers.length > 1
+                ? (round.contributions[_beneficiary][_answer] * round.feeRewards) / (round.paidFees[round.fundedAnswers[0]] + round.paidFees[round.fundedAnswers[1]])
+                : 0;
         } else if (question.answer == _answer) {
             uint256 paidFees = round.paidFees[_answer];
             // Reward the winner.
@@ -299,7 +301,7 @@ contract RealitioArbitratorProxyWithAppeals is IDisputeResolver {
         if (reward != 0) {
             round.contributions[_beneficiary][_answer] = 0;
             _beneficiary.transfer(reward);
-            emit Withdrawal(_questionID, _round, _answer, _beneficiary, reward);
+            emit Withdrawal(arbitrator, _questionID, _round, _answer, _beneficiary, reward);
         }
     }
 
@@ -353,7 +355,10 @@ contract RealitioArbitratorProxyWithAppeals is IDisputeResolver {
     ) external {
         Question storage question = questions[_questionID];
         require(question.status == Status.Ruled, "The status should be Ruled.");
-        require(realitio.getHistoryHash(bytes32(_questionID)) == keccak256(abi.encodePacked(_lastHistoryHash, _lastAnswerOrCommitmentID, _lastBond, _lastAnswerer, _isCommitment)), "The hash does not match.");
+        require(
+            realitio.getHistoryHash(bytes32(_questionID)) == keccak256(abi.encodePacked(_lastHistoryHash, _lastAnswerOrCommitmentID, _lastBond, _lastAnswerer, _isCommitment)),
+            "The hash does not match."
+        );
 
         question.status = Status.Reported;
         // Realitio ruling is shifted by 1 compared to Kleros, so we subtract 1 to bring it to Realitio format.
@@ -521,7 +526,9 @@ contract RealitioArbitratorProxyWithAppeals is IDisputeResolver {
                 } else if (!round.hasPaid[finalAnswer]) {
                     // Reimburse unspent fees proportionally if the ultimate winner didn't pay appeal fees fully.
                     // Note that if only one side is funded it will become a winner and this part of the condition won't be reached.
-                    sum += round.fundedAnswers.length > 1 ? (round.contributions[_beneficiary][answer] * round.feeRewards) / (round.paidFees[round.fundedAnswers[0]] + round.paidFees[round.fundedAnswers[1]]) : 0;
+                    sum += round.fundedAnswers.length > 1
+                        ? (round.contributions[_beneficiary][answer] * round.feeRewards) / (round.paidFees[round.fundedAnswers[0]] + round.paidFees[round.fundedAnswers[1]])
+                        : 0;
                 } else if (finalAnswer == answer) {
                     uint256 paidFees = round.paidFees[answer];
                     // Reward the winner.

--- a/contracts/RealitioProxyWithAppeals.sol
+++ b/contracts/RealitioProxyWithAppeals.sol
@@ -113,7 +113,7 @@ contract RealitioArbitratorProxyWithAppeals is IDisputeResolver {
     uint256 private loserAppealPeriodMultiplier; // Multiplier for calculating the duration of the appeal period for the loser, in basis points.
 
     mapping(uint256 => Question) public questions; // Maps a question ID to its data. questions[questionID].
-    mapping(uint256 => uint256) public override externalIDtoLocalID; // Maps external (arbitrator side) dispute ids to local dispute(question) ids.
+    mapping(uint256 => uint256) public externalIDtoLocalID; // Maps external (arbitrator side) dispute ids to local dispute(question) ids.
 
     /* Modifiers */
 
@@ -289,9 +289,7 @@ contract RealitioArbitratorProxyWithAppeals is IDisputeResolver {
         } else if (!round.hasPaid[question.answer]) {
             // Reimburse unspent fees proportionally if the ultimate winner didn't pay appeal fees fully.
             // Note that if only one side is funded it will become a winner and this part of the condition won't be reached.
-            reward = round.fundedAnswers.length > 1
-                ? (round.contributions[_beneficiary][_answer] * round.feeRewards) / (round.paidFees[round.fundedAnswers[0]] + round.paidFees[round.fundedAnswers[1]])
-                : 0;
+            reward = round.fundedAnswers.length > 1 ? (round.contributions[_beneficiary][_answer] * round.feeRewards) / (round.paidFees[round.fundedAnswers[0]] + round.paidFees[round.fundedAnswers[1]]) : 0;
         } else if (question.answer == _answer) {
             uint256 paidFees = round.paidFees[_answer];
             // Reward the winner.
@@ -355,10 +353,7 @@ contract RealitioArbitratorProxyWithAppeals is IDisputeResolver {
     ) external {
         Question storage question = questions[_questionID];
         require(question.status == Status.Ruled, "The status should be Ruled.");
-        require(
-            realitio.getHistoryHash(bytes32(_questionID)) == keccak256(abi.encodePacked(_lastHistoryHash, _lastAnswerOrCommitmentID, _lastBond, _lastAnswerer, _isCommitment)),
-            "The hash does not match."
-        );
+        require(realitio.getHistoryHash(bytes32(_questionID)) == keccak256(abi.encodePacked(_lastHistoryHash, _lastAnswerOrCommitmentID, _lastBond, _lastAnswerer, _isCommitment)), "The hash does not match.");
 
         question.status = Status.Reported;
         // Realitio ruling is shifted by 1 compared to Kleros, so we subtract 1 to bring it to Realitio format.
@@ -526,9 +521,7 @@ contract RealitioArbitratorProxyWithAppeals is IDisputeResolver {
                 } else if (!round.hasPaid[finalAnswer]) {
                     // Reimburse unspent fees proportionally if the ultimate winner didn't pay appeal fees fully.
                     // Note that if only one side is funded it will become a winner and this part of the condition won't be reached.
-                    sum += round.fundedAnswers.length > 1
-                        ? (round.contributions[_beneficiary][answer] * round.feeRewards) / (round.paidFees[round.fundedAnswers[0]] + round.paidFees[round.fundedAnswers[1]])
-                        : 0;
+                    sum += round.fundedAnswers.length > 1 ? (round.contributions[_beneficiary][answer] * round.feeRewards) / (round.paidFees[round.fundedAnswers[0]] + round.paidFees[round.fundedAnswers[1]]) : 0;
                 } else if (finalAnswer == answer) {
                     uint256 paidFees = round.paidFees[answer];
                     // Reward the winner.

--- a/test/arbitrable-proxy.js
+++ b/test/arbitrable-proxy.js
@@ -21,7 +21,7 @@ contract("ArbitrableProxy", ([sender, receiver, thirdParty, fourthParty, fifthPa
   });
 
   it("creates a dispute", async function () {
-    await this.ap.createDispute("0x00000", "", NUMBER_OF_RULING_OPTIONS, {
+    await this.ap.createDispute(this.aaa.address, "0x00000", "", NUMBER_OF_RULING_OPTIONS, {
       value: ARBITRATION_COST,
     });
 
@@ -32,13 +32,13 @@ contract("ArbitrableProxy", ([sender, receiver, thirdParty, fourthParty, fifthPa
     await this.aaa.giveAppealableRuling(0, 1, ARBITRATION_COST, 240);
     assert(new BN("1").eq((await this.aaa.disputes(0)).status));
 
-    await this.ap.fundAppeal(0, 1, {
+    await this.ap.fundAppeal(this.aaa.address, 0, 1, {
       // Fully funded
       value: ARBITRATION_COST * (1 + WINNER_STAKE_MULTIPLIER / DIVISOR),
       from: thirdParty,
     });
 
-    await this.ap.fundAppeal(0, 2, {
+    await this.ap.fundAppeal(this.aaa.address, 0, 2, {
       // Fully funded
       value: ARBITRATION_COST * (1 + LOSER_STAKE_MULTIPLIER / DIVISOR),
       from: fourthParty,
@@ -53,17 +53,17 @@ contract("ArbitrableProxy", ([sender, receiver, thirdParty, fourthParty, fifthPa
     let disputeStatus = (await this.aaa.disputes(0)).status;
     assert(new BN("1").eq(disputeStatus), `Expected disputeStatus 1, actual ${disputeStatus}`);
 
-    await this.ap.fundAppeal(0, 1, {
+    await this.ap.fundAppeal(this.aaa.address, 0, 1, {
       value: (ARBITRATION_COST * (1 + LOSER_STAKE_MULTIPLIER / DIVISOR)) / 2,
       from: thirdParty,
     });
-    await this.ap.fundAppeal(0, 1, {
+    await this.ap.fundAppeal(this.aaa.address, 0, 1, {
       value: (ARBITRATION_COST * (1 + LOSER_STAKE_MULTIPLIER / DIVISOR)) / 2,
       from: fifthParty,
     });
 
     const previousBalanceOfFourthParty = await web3.eth.getBalance(fourthParty);
-    const tx = await this.ap.fundAppeal(0, 2, {
+    const tx = await this.ap.fundAppeal(this.aaa.address, 0, 2, {
       value: ARBITRATION_COST * (1 + WINNER_STAKE_MULTIPLIER / DIVISOR) + 123456789,
       from: fourthParty,
     }); // 123456789 is excess value, should be sent back.
@@ -83,9 +83,9 @@ contract("ArbitrableProxy", ([sender, receiver, thirdParty, fourthParty, fifthPa
     const previousBalanceOfFourthParty = await web3.eth.getBalance(fourthParty);
     const previousBalanceOfFifthParty = await web3.eth.getBalance(fifthParty);
 
-    await this.ap.withdrawFeesAndRewardsForAllRounds(0, thirdParty, [...Array(NUMBER_OF_RULING_OPTIONS + 1).keys()]);
-    await this.ap.withdrawFeesAndRewardsForAllRounds(0, fourthParty, [...Array(NUMBER_OF_RULING_OPTIONS + 1).keys()]);
-    await this.ap.withdrawFeesAndRewardsForAllRounds(0, fifthParty, [...Array(NUMBER_OF_RULING_OPTIONS + 1).keys()]);
+    await this.ap.withdrawFeesAndRewardsForAllRounds(this.aaa.address, 0, thirdParty, [...Array(NUMBER_OF_RULING_OPTIONS + 1).keys()]);
+    await this.ap.withdrawFeesAndRewardsForAllRounds(this.aaa.address, 0, fourthParty, [...Array(NUMBER_OF_RULING_OPTIONS + 1).keys()]);
+    await this.ap.withdrawFeesAndRewardsForAllRounds(this.aaa.address, 0, fifthParty, [...Array(NUMBER_OF_RULING_OPTIONS + 1).keys()]);
 
     const currentBalanceOfThirdParty = await web3.eth.getBalance(thirdParty);
     const currentBalanceOfFourthParty = await web3.eth.getBalance(fourthParty);


### PR DESCRIPTION
Eliminated local dispute id variable, seems it was not really necessary.

It also saved significant gas. ~34K in total.
Before:
![old](https://user-images.githubusercontent.com/3106907/114639310-299cac00-9cd6-11eb-88f1-be1273312530.png)
After:
![new](https://user-images.githubusercontent.com/3106907/114639318-2e616000-9cd6-11eb-9ae4-5242624f4eeb.png)

